### PR TITLE
Enable Flyway and set Hibernate ddl-auto to validate

### DIFF
--- a/agenday-backend/src/main/resources/application.yml
+++ b/agenday-backend/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
       port: 6379
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: validate
     show-sql: false
 
 server:
@@ -21,3 +21,8 @@ jwt:
   secret: ${JWT_SECRET:senhasecreta}
   access-token-expiration: 900000
   refresh-token-expiration: 604800000
+
+flyway:
+  enabled: true
+  locations: classpath:db/migration
+  baseline-on-migrate: true

--- a/agenday-backend/src/main/resources/db/migration/V1__create_users_and_roles.sql
+++ b/agenday-backend/src/main/resources/db/migration/V1__create_users_and_roles.sql
@@ -1,0 +1,35 @@
+-- 1. Tabela de Permissões (Roles)
+CREATE TABLE roles (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name VARCHAR(50) UNIQUE NOT NULL
+);
+
+-- Inserindo as roles padrão do sistema Agenday
+INSERT INTO roles (name) VALUES
+    ('ROLE_CLIENT'),
+    ('ROLE_PROFESSIONAL'),
+    ('ROLE_ADMIN');
+
+-- 2. Tabela de Usuários
+CREATE TABLE users (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    email VARCHAR(255) UNIQUE NOT NULL,
+    password_hash VARCHAR(255), -- Aceita NULL para logins via Google
+    auth_provider VARCHAR(50) NOT NULL DEFAULT 'LOCAL', -- Ex: LOCAL, GOOGLE
+    provider_id VARCHAR(255), -- Guarda o ID único que vem do Google
+    full_name VARCHAR(255) NOT NULL,
+    phone VARCHAR(20),
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Índice para acelerar o login
+CREATE INDEX idx_users_email ON users(email);
+
+-- 3. Tabela de Relacionamento (Muitos-para-Muitos)
+CREATE TABLE user_roles (
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    role_id UUID NOT NULL REFERENCES roles(id) ON DELETE CASCADE,
+    PRIMARY KEY (user_id, role_id)
+);

--- a/agenday-backend/src/main/resources/db/migration/V2__create_professionals.sql
+++ b/agenday-backend/src/main/resources/db/migration/V2__create_professionals.sql
@@ -1,0 +1,19 @@
+CREATE TABLE professionals (
+    id UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+
+
+    -- URL amigável para a página de agendamento (/agendar/:slug)
+    slug VARCHAR(255) UNIQUE NOT NULL,
+
+    -- Descrição do profissional e seus serviços
+    bio TEXT,
+
+    -- Link para a imagem hospedada no Cloudflare R2
+    profile_image_url VARCHAR(500),
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Índice crítico para buscas rápidas pela página pública
+CREATE INDEX idx_professionals_slug ON professionals(slug);

--- a/agenday-backend/target/classes/application.yml
+++ b/agenday-backend/target/classes/application.yml
@@ -11,7 +11,7 @@ spring:
       port: 6379
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: validate
     show-sql: false
 
 server:
@@ -21,3 +21,8 @@ jwt:
   secret: ${JWT_SECRET:senhasecreta}
   access-token-expiration: 900000
   refresh-token-expiration: 604800000
+
+flyway:
+  enabled: true
+  locations: classpath:db/migration
+  baseline-on-migrate: true


### PR DESCRIPTION
Change application.yml to use Hibernate ddl-auto=validate instead of none and add Flyway configuration (enabled: true, locations: classpath:db/migration, baseline-on-migrate: true). Updates are applied to both src/main/resources and the generated target/classes file. This ensures the app validates the schema at startup and runs/recognizes DB migrations (baseline used for existing schemas).